### PR TITLE
fix: add more resources for css, tools and diagrams, fix different colors of theme toggle button and scroll to top button, fix padding-left for search bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
                     <li><a href="https://watercss.kognise.dev/" target="_blank">WaterCSS</a></li>
                     <li><a href="https://omatsuri.app/gradient-generator" target="_blank">Gradient Generator</a></li>
                     <li><a href="https://omatsuri.app/page-dividers" target="_blank">Page-Dividers</a></li>
+                    <li><a href="https://flexboxfroggy.com/" target="_blank">Flexbox Froggy</a></li>
                 </ul>
             </div>
 
@@ -170,6 +171,7 @@
                     <li><a href="https://lucidchart.com/" target="_blank">Lucidchart</a></li>
                     <li><a href="https://draw.io/" target="_blank">Draw.io</a></li>
                     <li><a href="https://www.websequencediagrams.com/" target="_blank">Web Sequence Diagram</a></li>
+                    <li><a href="https://excalidraw.com/" target="_blank">Excalidraw</a></li>
                 </ul>
             </div>
 
@@ -226,6 +228,7 @@
                     <li><a href="https://overapi.com/" target="_blank">overapi</a></li>
                     <li><a href="https://roadmap.sh/" target="_blank">roadmap</a></li>
                     <li><a href="https://caniuse.com/" target="_blank">Can I use</a></li>
+                    <li><a href="https://replit.com/" target="_blank">Replit</a></li>
                 </ul>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -82,6 +82,7 @@ h1 {
     background-color: var(--card-bg);
     color: var(--text);
     box-shadow: 0 2px 10px rgba(4, 3, 5, 0.1);
+    padding-left: 20px;
 }
 
 .category-filter {
@@ -180,7 +181,7 @@ h1 {
     position: fixed;
     bottom: 20px;
     left: 20px;
-    background-color: #bb80ff;
+    background-color: var(--primary);
     color: #fff;
     border: none;
     border-radius: 50%;


### PR DESCRIPTION
## Added `flexbox froggy` game in css resources, added `excalidraw` in diagrams resources and added `replit` in tools resources.

## Fixed different colors of the toggle button and scroll to top button.

### Previously:

![image](https://github.com/user-attachments/assets/52d68517-b6f2-48c1-a16f-d50322521db0)

### After
![image](https://github.com/user-attachments/assets/db3a4406-f0ee-4d81-901d-e77251381085)

## Fixed padding-left in the search bar, previously it looked packed up.

### Previously
![image](https://github.com/user-attachments/assets/dbe5d353-6627-4ed2-a74a-17ccca0eccbb)

### After
![image](https://github.com/user-attachments/assets/6f2f1d04-82f8-4ee9-9b45-98c842c2cc1d)
