### PR TITLE
fix: add resources for icons and backgrounds, also fixed the width of h3 tag (hover-tag class) to take up only as much space as the text

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
                     <li><a href="https://bansal.io/pattern-css" target="_blank">Pattern CSS</a></li>
                     <li><a href="https://www.wallpaperflare.com/" target="_blank">Wallpaperflare</a></li>
                     <li><a href="https://www.unsplash.com/" target="_blank">Unsplash</a></li>
+                    <li><a href="https://www.freepik.com/" target="_blank">Freepik</a></li>
                 </ul>
             </div>
 
@@ -200,6 +201,7 @@
                     <li><a href="https://www.flaticon.com/" target="_blank">Flaticon</a></li>
                     <li><a href="https://icons8.com/" target="_blank">Icons8</a></li>
                     <li><a href="https://lordicon.com/" target="_blank">Lordicon</a></li>
+                    <li><a href="https://iconscout.com/" target="_blank">IconScout</a></li>
                 </ul>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -36,6 +36,7 @@ body {
 .hover-text {
     color: black;
     transition: color 0.3s;
+    display: inline-block;
 }
 
 .hover-text:hover {


### PR DESCRIPTION
## Added other resources for icons i.e iconscout and for background i.e freepik.com

## Fixed the width of the h3 tag to take up as much space as the text.

## Before

![Screenshot 2024-10-16 182347](https://github.com/user-attachments/assets/f68e5e82-441f-4c12-813f-55a73c0a2068)


## After

![Screenshot 2024-10-16 182401](https://github.com/user-attachments/assets/015b7fad-2d12-4daa-bce4-c6834d8a9e99)
