### PR TITLE
Fix: fix extra top margin at h1 and small h1 size on mobile screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,6 +61,7 @@ h1 {
   -webkit-text-fill-color: transparent;
   animation: gradientText 5s ease infinite;
   font-weight: normal;
+  margin-top: 0;
 }
 
 span {
@@ -241,7 +242,7 @@ a:hover {
 
 @media (max-width: 768px) {
   h1 {
-    font-size: 2.5rem;
+    font-size: 3.5rem;
     margin-bottom: 20px;
   }
 


### PR DESCRIPTION
## The `h1` tag at the starting had extra gap present in it

![Screenshot 2024-10-27 103553](https://github.com/user-attachments/assets/ec045dda-6ef9-426d-8377-dcad8affc219)

## It is now fixed to

![Screenshot 2024-10-27 105807](https://github.com/user-attachments/assets/4cabd14c-9444-4fc1-a94b-64ffc208e51b)

## When in mobile view the heading looked too small

![Screenshot 2024-10-27 105740](https://github.com/user-attachments/assets/8c0da469-c234-4c60-9f61-94db825ef62a)

## It is now fixed to
![Screenshot 2024-10-27 105751](https://github.com/user-attachments/assets/6aca5681-1fde-4bab-b011-c9207066b6f7)

